### PR TITLE
Made the navbar shorter, adjusted the titles in navbar proportionally, and modified blue title font on Home, About and Resource pages to Oswald

### DIFF
--- a/homestead/public/index.html
+++ b/homestead/public/index.html
@@ -9,6 +9,14 @@
       name="description"
       content="Web site created using create-react-app"
     />
+     
+    <!--
+      Oswald Regular 400 font
+    -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Oswald&display=swap" rel="stylesheet">
+
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/homestead/src/Home.css
+++ b/homestead/src/Home.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Oswald:wght@3docker-compose stop00&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Oswald&display=swap');
 .home_masthead {
   display: block;
   margin: 150px auto 0;

--- a/homestead/src/Home.css
+++ b/homestead/src/Home.css
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css2?family=Oswald:wght@3docker-compose stop00&display=swap');
 .home_masthead {
   display: block;
   margin: 150px auto 0;
@@ -19,8 +20,7 @@
 
 
 .home_propagandaBubble > h2 {
-  font-family: var(--font-form);
-  font-weight: 900;
+  font-family: 'Oswald', sans-serif;
   font-size: 36px;
   color: var(--circlek-color);
 }
@@ -38,8 +38,7 @@
 }
 
 .home_mid > h2 {
-  font-family: var(--font-form);
-  font-weight: 900;
+  font-family: 'Oswald', sans-serif;
   font-size: 36px;
   color: var(--circlek-color);
   margin: 0 0 30px;
@@ -62,8 +61,7 @@
 }
 
 .home_midLower > h2 {
-  font-family: var(--font-form);
-  font-weight: 900;
+  font-family: 'Oswald', sans-serif;
   font-size: 36px;
   color: var(--circlek-color);
   margin: 0 0 30px;
@@ -93,8 +91,7 @@
 }
 
 .home_tenents > h2 {
-  font-family: var(--font-form);
-  font-weight: 900;
+  font-family: 'Oswald', sans-serif;
   font-size: 36px;
   color: var(--circlek-color);
 }
@@ -123,8 +120,7 @@
   }
   
   .home_propagandaBubble > h2 {
-    font-family: var(--font-form);
-    font-weight: 900;
+    font-family: 'Oswald', sans-serif;
     font-size: 36px;
     color: var(--circlek-color);
   }
@@ -146,8 +142,7 @@
   }
   
   .home_mid > h2 {
-    font-family: var(--font-form);
-    font-weight: 900;
+    font-family: 'Oswald', sans-serif;
     font-size: 36px;
     color: var(--circlek-color);
     margin: 0 0 30px;
@@ -170,8 +165,7 @@
   }
   
   .home_midLower > h2 {
-    font-family: var(--font-form);
-    font-weight: 900;
+    font-family: 'Oswald', sans-serif;
     font-size: 36px;
     color: var(--circlek-color);
     margin: 0 0 30px;
@@ -201,8 +195,7 @@
   }
   
   .home_tenents > h2 {
-    font-family: var(--font-form);
-    font-weight: 900;
+    font-family: 'Oswald', sans-serif;
     font-size: 36px;
     color: var(--circlek-color);
   }

--- a/homestead/src/Home.css
+++ b/homestead/src/Home.css
@@ -1,7 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Oswald&display=swap');
 .home_masthead {
   display: block;
-  margin: 150px auto 0;
+  margin: 100px auto 0;
   max-width: 100%;
   max-height: 600px;
 
@@ -99,7 +99,7 @@
 @media only screen and (min-width: 1024px) {
   .home_masthead {
     display: block;
-    margin: 120px auto 20px;
+    margin: 105px auto 0;
     max-width: 90%;
   }
   

--- a/homestead/src/Navbar.css
+++ b/homestead/src/Navbar.css
@@ -1,7 +1,7 @@
 .navbar {
   background-color: var(--circlek-color);
   justify-content: center;
-  height: 150px;
+  height: 100px;
   width: 100%;
   position: fixed;
   z-index: 100;
@@ -14,7 +14,7 @@
 
 .navbar_inner {
   position: relative;
-  top: 30px;
+  top: 10px;
   margin: 0 auto;
   max-width: 1500px;
   width: 95%;
@@ -32,7 +32,7 @@
 }
 
 .navbar_title > h1 {
-  font-size: 60px;
+  font-size: 80px;
   text-align: center;
   font-family: var(--font-form);
   color: var(--background-color);
@@ -60,7 +60,7 @@
   .navbar {
     background-color: var(--circlek-color);
     justify-content: center;
-    height: 150px;
+    height: 100px;
     width: 100%;
     position: fixed;
     z-index: 100;
@@ -73,7 +73,7 @@
   
   .navbar_inner {
     position: relative;
-    top: 30px;
+    top: 10px;
     margin: 0 auto;
     max-width: 1500px;
     width: 95%;
@@ -91,7 +91,7 @@
   }
   
   .navbar_title > h1 {
-    font-size: 100px;
+    font-size: 80px;
     text-align: center;
     font-family: var(--font-form);
     color: var(--background-color);

--- a/homestead/src/Navbar.css
+++ b/homestead/src/Navbar.css
@@ -1,3 +1,16 @@
+h1 {
+  display: block;
+  margin-inline-start: 0px;
+  margin-inline-end: 0px;
+  font-weight: bold;
+} 
+h2 {
+  display: block;
+  margin-inline-start: 0px;
+  margin-inline-end: 0px;
+  font-weight: bold;
+}
+
 .navbar {
   background-color: var(--circlek-color);
   justify-content: center;
@@ -22,17 +35,18 @@
   flex-direction: column;
   align-items: baseline;
   justify-content: space-between;
+  height:50%;
 }
 
 .navbar_title {
   display: flex;
   align-items: baseline;
   position: relative;
-  bottom: 20px;
+  /* bottom: 0px; */
 }
 
 .navbar_title > h1 {
-  font-size: 80px;
+  font-size: 50px;
   text-align: center;
   font-family: var(--font-form);
   color: var(--background-color);
@@ -57,6 +71,18 @@
 }
 
 @media only screen and (min-width: 1024px) {
+  h1 {
+    display: block;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+    font-weight: bold;
+  } 
+  h2 {
+    display: block;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+    font-weight: bold;
+  }
   .navbar {
     background-color: var(--circlek-color);
     justify-content: center;
@@ -69,6 +95,7 @@
     background-position: left top;
     background-size: contain;
     background-repeat: no-repeat; 
+    padding-top: 6px;
   }
   
   .navbar_inner {
@@ -87,11 +114,11 @@
     display: flex;
     align-items: baseline;
     position: relative;
-    bottom: 0px;
+    /* bottom: 0px; */
   }
   
   .navbar_title > h1 {
-    font-size: 80px;
+    font-size: 70px;
     text-align: center;
     font-family: var(--font-form);
     color: var(--background-color);

--- a/homestead/src/Navbar.css
+++ b/homestead/src/Navbar.css
@@ -42,7 +42,6 @@ h2 {
   display: flex;
   align-items: baseline;
   position: relative;
-  /* bottom: 0px; */
 }
 
 .navbar_title > h1 {
@@ -114,7 +113,6 @@ h2 {
     display: flex;
     align-items: baseline;
     position: relative;
-    /* bottom: 0px; */
   }
   
   .navbar_title > h1 {

--- a/homestead/src/NavbarOption.css
+++ b/homestead/src/NavbarOption.css
@@ -1,6 +1,6 @@
 .navbarOption {
   margin: 5px 2px;
-  padding: 0 0 10px;
+  padding: 0 0 0px;
 }
 
 .navbarOption:hover {
@@ -21,7 +21,7 @@
 @media only screen and (min-width: 768px) {
   .navbarOption {
     margin: 5px;
-    padding: 0 0 10px;
+    padding: 0 0 0px;
   }
   
   .navbarOption:hover {

--- a/homestead/src/about/subCategories/General.css
+++ b/homestead/src/about/subCategories/General.css
@@ -1,6 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Oswald&display=swap');
 .general {
-    margin: 200px 0 0;
+    margin: 150px 0 0;
 }
 
 .general_sub {
@@ -86,7 +86,7 @@
 
 @media only screen and (min-width: 1024px) {
     .general {
-        margin: 200px 0 0;
+        margin: 150px 0 0;
     }
     
     .general_sub {

--- a/homestead/src/about/subCategories/General.css
+++ b/homestead/src/about/subCategories/General.css
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css2?family=Oswald&display=swap');
 .general {
     margin: 200px 0 0;
 }
@@ -16,8 +17,7 @@
 
 .general_text1 > h2 {
     flex: 0.2;
-    font-family: var(--font-form);
-    font-weight: 900;
+    font-family: 'Oswald', sans-serif;
     font-size: 36px;
     color: var(--circlek-color);
     margin: 5px 0;
@@ -37,8 +37,7 @@
 }
 
 .general_events > h2 {
-    font-family: var(--font-form);
-    font-weight: 900;
+    font-family: 'Oswald', sans-serif;
     font-size: 36px;
     color: var(--circlek-color);
     position: relative;
@@ -56,8 +55,7 @@
 }
 
 .general_sub > h1 {
-    font-family: var(--font-form);
-    font-weight: 900;
+    font-family: 'Oswald', sans-serif;
     font-size: 36px;
     color: var(--circlek-color);
     margin: 40px 0 20px;
@@ -105,8 +103,7 @@
     
     .general_text1 > h2 {
         flex: 0.2;
-        font-family: var(--font-form);
-        font-weight: 900;
+        font-family: 'Oswald', sans-serif;
         font-size: 36px;
         color: var(--circlek-color);
         margin: 0;
@@ -126,8 +123,7 @@
     }
     
     .general_events > h2 {
-        font-family: var(--font-form);
-        font-weight: 900;
+        font-family: 'Oswald', sans-serif;
         font-size: 36px;
         color: var(--circlek-color);
         position: relative;
@@ -146,8 +142,7 @@
     }
     
     .general_sub > h1 {
-        font-family: var(--font-form);
-        font-weight: 900;
+        font-family: 'Oswald', sans-serif;
         font-size: 36px;
         color: var(--circlek-color);
         margin: 40px 0 20px;

--- a/homestead/src/about/subCategories/OurClub.css
+++ b/homestead/src/about/subCategories/OurClub.css
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css2?family=Oswald&display=swap');
 .ourClub {
     margin: 200px 0 0;
 }
@@ -16,8 +17,7 @@
 
 .ourClub_text1 > h2 {
     flex: 0.25;
-    font-family: var(--font-form);
-    font-weight: 900;
+    font-family: 'Oswald', sans-serif;
     font-size: 36px;
     color: var(--circlek-color);
     margin: 0 0 10px;
@@ -38,8 +38,7 @@
 
 .ourClub_events > h2 {
     flex: 0.25;
-    font-family: var(--font-form);
-    font-weight: 900;
+    font-family: 'Oswald', sans-serif;
     font-size: 36px;
     color: var(--circlek-color);
 }
@@ -101,7 +100,6 @@
 
 .ourClub_board > h2 {
     font-family: var(--font-form);
-    font-weight: 900;
     font-size: 32px;
     color: black;
 }
@@ -151,8 +149,7 @@
     
     .ourClub_text1 > h2 {
         flex: 0.25;
-        font-family: var(--font-form);
-        font-weight: 900;
+        font-family: 'Oswald', sans-serif;
         font-size: 36px;
         color: var(--circlek-color);
         margin: 0;
@@ -173,8 +170,7 @@
     
     .ourClub_events > h2 {
         flex: 0.25;
-        font-family: var(--font-form);
-        font-weight: 900;
+        font-family: 'Oswald', sans-serif;
         font-size: 36px;
         color: var(--circlek-color);
     }

--- a/homestead/src/about/subCategories/OurClub.css
+++ b/homestead/src/about/subCategories/OurClub.css
@@ -1,6 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Oswald&display=swap');
 .ourClub {
-    margin: 200px 0 0;
+    margin: 150px 0 0;
 }
 
 .ourClub_sub {
@@ -132,7 +132,7 @@
 
 @media only screen and (min-width: 1024px) {
     .ourClub {
-        margin: 200px 0 0;
+        margin: 150px 0 0;
     }
     
     .ourClub_sub {

--- a/homestead/src/about/subCategories/Structure.css
+++ b/homestead/src/about/subCategories/Structure.css
@@ -1,6 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Oswald&display=swap');
 .structure {
-    margin: 200px 0 0;
+    margin: 150px 0 0;
 }
 
 .structure_sub {
@@ -127,7 +127,7 @@
 
 @media only screen and (min-width: 1024px) {
     .structure {
-        margin: 200px 0 0;
+        margin: 150px 0 0;
     }
     
     .structure_sub {

--- a/homestead/src/about/subCategories/Structure.css
+++ b/homestead/src/about/subCategories/Structure.css
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css2?family=Oswald&display=swap');
 .structure {
     margin: 200px 0 0;
 }
@@ -17,7 +18,7 @@
 .structure_text1 > h2 {
     flex: 0.2;
     margin: 10px 0;
-    font-family: var(--font-form);
+    font-family: 'Oswald', sans-serif;
     font-weight: 900;
     font-size: 36px;
     color: var(--circlek-color);
@@ -53,7 +54,7 @@
 
 .structure_district > h2 {
     flex: 0.3;
-    font-family: var(--font-form);
+    font-family: 'Oswald', sans-serif;
     font-weight: 900;
     font-size: 36px;
     color: var(--circlek-color);
@@ -77,7 +78,7 @@
 
 .structure_clubs > h2 {
     flex: 0.3;
-    font-family: var(--font-form);
+    font-family: 'Oswald', sans-serif;
     font-weight: 900;
     font-size: 36px;
     color: var(--circlek-color)
@@ -144,8 +145,7 @@
     .structure_text1 > h2 {
         flex: 0.2;
         margin: 0;
-        font-family: var(--font-form);
-        font-weight: 900;
+        font-family: 'Oswald', sans-serif;
         font-size: 36px;
         color: var(--circlek-color);
     }
@@ -180,7 +180,7 @@
     
     .structure_district > h2 {
         flex: 0.3;
-        font-family: var(--font-form);
+        font-family: 'Oswald', sans-serif;
         font-weight: 900;
         font-size: 36px;
         color: var(--circlek-color);
@@ -204,7 +204,7 @@
     
     .structure_clubs > h2 {
         flex: 0.3;
-        font-family: var(--font-form);
+        font-family: 'Oswald', sans-serif;
         font-weight: 900;
         font-size: 36px;
         color: var(--circlek-color)

--- a/homestead/src/account/Account.css
+++ b/homestead/src/account/Account.css
@@ -1,6 +1,11 @@
+@import url('https://fonts.googleapis.com/css2?family=Oswald&display=swap');
 .account {
   margin: 200px auto 0;
   max-width: 95%;
+}
+
+.account > h2 {
+  font-family: 'Oswald', sans-serif;
 }
 
 .account_title {

--- a/homestead/src/account/Account.css
+++ b/homestead/src/account/Account.css
@@ -1,6 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Oswald&display=swap');
 .account {
-  margin: 200px auto 0;
+  margin: 110px auto 0;
   max-width: 95%;
 }
 
@@ -252,7 +252,7 @@
 
 @media only screen and (min-width: 1024px) {
   .account {
-    margin: 200px auto 0;
+    margin: 150px auto 0;
     max-width: 90%;
     min-width: 1000px;
   }

--- a/homestead/src/calendar/Calendar.css
+++ b/homestead/src/calendar/Calendar.css
@@ -1,5 +1,5 @@
 .calendar {
-  margin: 200px auto 0;
+  margin: 110px auto 0;
   width: 95%;
 }
 
@@ -49,7 +49,7 @@
 
 @media only screen and (min-width: 1024px) {
   .calendar {
-    margin: 300px auto 0;
+    margin: 175px auto 0;
     max-width: 1920px;
     width: 95%;
   }

--- a/homestead/src/calendar/calendarCogs/CalendarCogs.css
+++ b/homestead/src/calendar/calendarCogs/CalendarCogs.css
@@ -9,7 +9,7 @@
 .calendarCogs_months > h1{
   color: var(--circlek-color);
   font-family: var(--font-form);
-  font-size: 50px;
+  font-size: 25px;
   font-weight: 800;
 }
 

--- a/homestead/src/login/LParent.css
+++ b/homestead/src/login/LParent.css
@@ -1,7 +1,7 @@
 .lparent_upper {
     display: flex;
     max-width: 1000px;
-    margin: 200px auto 110px;
+    margin: 120px auto 110px;
     flex-direction: column;
 }
 
@@ -66,7 +66,7 @@
     .lparent_upper {
         display: flex;
         max-width: 1000px;
-        margin: 200px auto 110px;
+        margin: 150px auto 110px;
         flex-direction: row;
     }
     


### PR DESCRIPTION
Changed the height of the navbar to be shorter and then changed the size of the logo to match. Imported (link) Oswald Regular 400 in the index.html and changed the font of h1 on the Home page to Oswald in the stylesheet.

Update (8/18/21): Adjusted the navbar - 1) The white lines below the titles are shown 2) When the website is viewed in mobile view, the two titles are now shown properly on the navbar as two rows. Also, changed the blue title fonts on the About and Resource pages. 